### PR TITLE
mvp-0.5.1: fix-dispatcher concept correction + verbose logging

### DIFF
--- a/mvp/mvp-0.5.1/README.md
+++ b/mvp/mvp-0.5.1/README.md
@@ -8,6 +8,20 @@
 
 **研究层**：利用工程化手段**从根本上理解和解决 LLM 不确定性**。每个 MVP 迭代不仅是功能新增，更是对 LLM 行为模式的系统探索。
 
+## 概念订正：树内路由 ≠ 横切调用
+
+在回顾研究进展前，需要先澄清一个本仓库一度混淆的核心概念。
+
+**树内路由（合法）**：子节点内部 dispatch 到自己的子子树，即调用自己的后代节点。这是完全合法的——父节点调用该子节点，子节点再调用它自己的子节点，整个链条遵循树结构。例如一个 `ExecuteCommand` 子节点内部根据命令类型路由到 `CmdCreate`、`CmdRead` 等（这些是 `ExecuteCommand` 的子节点，不是兄弟节点）。
+
+**横切调用（非法）**：子节点调用它的兄弟节点。这是对树结构的违反——父节点才是唯一协调者。例如 `Root` 有子节点 `[ParseInput, RouteCommand, AddExpense, ListExpenses]`，而 `RouteCommand` 在代码中调用了 `AddExpense` 和 `ListExpenses`（它们是 `RouteCommand` 的兄弟）。
+
+**关键判断标准**：
+- 子节点调用兄弟？→ **非法（横切）**
+- 子节点内部自己做 dispatch 到自己子树？→ **合法（树内路由）**
+
+**本仓库此前将两者混为一谈，统称为"dispatcher 模式"并视为违规。** 许多 README 和研究笔记使用了"dispatcher 模式"这个有歧义的标签。实际被验证器拦截的案例全都是**横切调用**而非树内路由。真正的架构规则不需要禁止"路由"，只需要禁止"子节点调用兄弟"。
+
 ## 本版本研究进展
 
 ### 强制输出：能缓解，不能治愈
@@ -17,8 +31,8 @@
 | 机制 | 解决的问题 | 局限性 |
 |------|-----------|--------|
 | JSON Mode（`response_format: json_object`） | 输出格式不可解析 | LLM 可以在 JSON 内塞任意内容 |
-| 两步代码生成（REVIEW → IMPLEMENT） | LLM 跳过关键检查（65%→100% 检出格式问题） | 不能检出结构性问题（dispatcher 模式） |
-| Step 2 VERIFY（独立 LLM 自检） | 隔离审查，有代码可追溯 | 语义层面松弛匹配，**漏放 dispatcher** |
+| 两步代码生成（REVIEW → IMPLEMENT） | LLM 跳过关键检查（65%→100% 检出格式问题） | 不能检出结构性问题（横切调用模式） |
+| Step 2 VERIFY（独立 LLM 自检） | 隔离审查，有代码可追溯 | 语义层面松弛匹配，**漏放横切调用** |
 | 签名锁定（Signature Locking） | 函数签名不匹配 | 不解决分解结构错误 |
 
 关键发现：**强制输出可以让 LLM 遵守格式约束，但不能让 LLM 遵守架构约束。** 后者需要 LLM 在语义层面理解并执行规则，而 LLM 的"理解"是概率性的。
@@ -40,7 +54,7 @@ AST Validator（确定性调用图分析）
 
 这暴露了 LLM 作为验证器的固有缺陷：**LLM 做语义匹配，不做确定性执行。** 当规则要求"出现 `ChildName(` 模式"时，LLM 内部将其松弛为"看起来用到了这个 child"。
 
-**重要推论**：验证器（Validator）永远只是下游补丁，不是主战场。真正的问题在分解阶段——LLM 为什么反复产生 dispatcher 模式？
+**重要推论**：验证器（Validator）永远只是下游补丁，不是主战场。真正的问题在分解阶段——LLM 为什么反复在兄弟层级间引入横切调用？
 
 ### LLM 心智模型
 
@@ -48,11 +62,11 @@ AST Validator（确定性调用图分析）
 
 1. **LLM 有自己的"直觉架构"**——它认为 route_command 与 CRUD handlers 是"同一抽象层级"，因为"都是命令处理操作"。这不是随机错误，而是 LLM 对软件架构的固有认知模式。
 
-2. **推理模型可自我纠正**——deepseek-reasoner 在 CoT 中会自行否定创建 dispatcher 的第一直觉，最终正确分解。chat 模型跳过推理直接输出第一直觉。
+2. **推理模型可自我纠正**——deepseek-reasoner 在 CoT 中会自行否定创建横切路由的第一直觉，最终正确分解。chat 模型跳过推理直接输出第一直觉。
 
-3. **提示词级别的禁止无效**——即使加入"children MUST NOT call each other"，deepseek-chat 仍约 80% 创建 RouteCommand。LLM 不是不理解规则，而是它的"架构直觉"压过了规则的表面约束。
+3. **提示词级别的禁止无效**——即使加入"children MUST NOT call each other"，deepseek-chat 仍约 80% 在兄弟层级间创建路由节点。LLM 不是不理解规则，而是它的"架构直觉"压过了规则的表面约束。
 
-4. **LLM 在"生产模式"和"审查模式"下行为不同**——同一模型在中立逐规则审查中能明确拒绝 dispatcher，但在生成代码时（"生产模式"）不会批判性审视自己的分解结构。
+4. **LLM 在"生产模式"和"审查模式"下行为不同**——同一模型在中立逐规则审查中能明确拒绝横切路由节点，但在生成代码时（"生产模式"）不会批判性审视自己的分解结构。
 
 ### 核心矛盾
 
@@ -78,7 +92,7 @@ PRD: 订单管理系统
 接口: 18
 生成代码文件: 48
 最大深度: 5
-重分解轮次: 3 (根节点 dispatcher 模式被拒绝)
+重分解轮次: 3 (根节点存在横切调用，被 AST Validator 拒绝)
 结果: Validation PASSED
 ```
 
@@ -89,13 +103,13 @@ PRD: 订单管理系统
 
 - `RefundBalance` 节点 codegen 失败，capability 分配不完整
 - Max redecompose retries（3）耗尽后未自动恢复
-- VERIFY 对 dispatcher 模式间歇性漏放
+- VERIFY 对横切调用模式间歇性漏放（但 AST Validator 能确定性拦截）
 
 ## 测试套件
 
 ```
 tests/
-├── test_codegen_verify_cannot_compose.py  # VERIFY 拒绝 dispatcher 测试
+├── test_codegen_verify_cannot_compose.py  # VERIFY + AST 拦截横切调用测试
 ├── test_formal_leaf_rejection.py           # 叶节点能力拒绝（15/15）
 └── test_e2e_redecompose.py                 # 端到端重分解（2/2）
 ```
@@ -133,12 +147,16 @@ python main.py --input ../../benchmark/test_cases/medium/order_prd.md --output o
 | 0.2.0 | JsonPRD/SubPRD 解决信息丢失 | 改善，但 LLM 输出不稳定 |
 | 0.2.1 | JSON Mode 强制格式 | 格式稳定了，内容仍不可控 |
 | 0.3.1 | 签名锁定 + AttemptRecord 减少重犯 | 签名合规提升，分解结构未改善 |
-| 0.4.1-2 | Interface Layer 隔离全局变量访问 | 叶节点更可靠，但 dispatcher 模式未解决 |
+| 0.4.1-2 | Interface Layer 隔离全局变量访问 | 叶节点更可靠，但横切调用模式未解决 |
 | 0.4.3-4 | Architecture Feedback Loop（CANNOT_COMPOSE + INSUFFICIENT_CAPABILITIES） | 反馈回路完整，但 LLM compliance 仍不稳定 |
-| 0.5.1 | 强制 VERIFY 两步自检拦截 dispatcher | **部分有效**——VERIFY 不可靠，AST Validator 是真正 enforcement 点 |
+| 0.5.1 | 强制 VERIFY 两步自检拦截横切调用 + AST Validator 确定性调用图分析 | VERIFY 部分有效但不可靠，AST Validator 是真正 enforcement 点 |
+
+注：0.1~0.5.1 版本中所有提及"dispatcher 模式"的地方实际都指**横切调用**（子节点调用兄弟节点），而非树内路由。后者是合法的架构模式。
 
 ## 核心认识
 
-**验证器不是主战场。** 确定性校验（AST Validator）可以拦截错误，但不能预防错误。真正的问题是：LLM 为什么在分解阶段反复产生违反架构的模式？
+**验证器不是主战场。** 确定性校验（AST Validator）可以拦截错误，但不能预防错误。真正的问题是：LLM 为什么在分解阶段反复在兄弟层级间创建横切路由？
+
+LLM 对"抽象层级"的感知与人类架构师不同——它倾向于将所有"命令处理"放在同一层级，创建一个路由节点来协调同级的处理节点。这个认知偏差不能通过提示词规则或强制输出来根治。
 
 这个仓库的目的不是"让 LLM 输出正确的代码"，而是**通过工程手段理解 LLM 的认知模式，设计与之兼容的架构约束**。强制输出、验证器、提示词规则都是表面工具——真正的答案藏在对 LLM "心智"的更深理解中。

--- a/mvp/mvp-0.5.1/code_generator.py
+++ b/mvp/mvp-0.5.1/code_generator.py
@@ -699,6 +699,13 @@ When status is "insufficient_capabilities", do NOT attempt to generate any code.
         except Exception as e:
             return "", [f"API call failed: {e}"]
 
+        if self.config.verbose:
+            print("\n" + "=" * 60)
+            print("CODEGEN STAGE 1 — REVIEW + IMPLEMENT RAW RESPONSE")
+            print("=" * 60)
+            print(response[:2000])
+            print("=" * 60 + "\n")
+
         parsed = self._parse_response(response)
         status = parsed.get("status", "ok")
         node.composition_feedback = None
@@ -725,6 +732,13 @@ When status is "insufficient_capabilities", do NOT attempt to generate any code.
         except Exception as e:
             print(f"Verification step failed, accepting step 1 code: {e}")
             return code, []
+
+        if self.config.verbose:
+            print("\n" + "=" * 60)
+            print("CODEGEN STAGE 2 — VERIFY RAW RESPONSE")
+            print("=" * 60)
+            print(verify_response[:2000])
+            print("=" * 60 + "\n")
 
         verify_parsed = self._parse_response(verify_response)
         verify_status = verify_parsed.get("status", "ok")
@@ -763,6 +777,11 @@ When status is "insufficient_capabilities", do NOT attempt to generate any code.
             response = self.api_client.chat(messages, max_tokens=2048)
         except Exception as e:
             return "", [f"API call failed: {e}"]
+
+        if self.config.verbose:
+            print(f"\nLEAF CODEGEN RAW RESPONSE [{node.name}]:")
+            print(response[:1500])
+            print()
 
         parsed = self._parse_response(response)
         status = parsed.get("status", "ok")

--- a/mvp/mvp-0.5.1/config.py
+++ b/mvp/mvp-0.5.1/config.py
@@ -22,13 +22,16 @@ class Config:
     max_decompose_retries: int = 3
     timeout: int = 120
     
+    verbose: bool = False
+
     output_dir: str = "output"
     nodes_dir: str = "output/nodes"
-    
+
     def __post_init__(self):
         if self.api_key is None:
             self.api_key = os.getenv("DEEPSEEK_API_KEY")
-    
+        self.verbose = self.verbose or os.getenv("VERBOSE", "").lower() in ("1", "true", "yes")
+
     @classmethod
     def from_env(cls) -> "Config":
         return cls(

--- a/mvp/mvp-0.5.1/decomposer.py
+++ b/mvp/mvp-0.5.1/decomposer.py
@@ -373,17 +373,27 @@ class Decomposer:
             return node, [f"API call failed: {e}"]
         
         parsed = self._parse_response(response)
-        
+
+        if self.config.verbose:
+            print("\n" + "=" * 60)
+            print("DECOMPOSER RAW LLM RESPONSE")
+            print("=" * 60)
+            print(f"Node: {node.name}")
+            print(f"Rationale: {parsed.get('decomposition_rationale', 'N/A')[:500]}")
+            cdata = parsed.get("children", [])
+            print(f"Children ({len(cdata)}):")
+            for cd in cdata:
+                name = cd.get("name", "?")
+                ntype = cd.get("node_type", "?")
+                purpose = cd.get("purpose", "")[:80]
+                stop = cd.get("stop_decompose", False)
+                print(f"  - {name} [{ntype}] stop={stop} | {purpose}")
+            print("=" * 60 + "\n")
+
         if "error" in parsed:
             return node, [f"Failed to parse LLM response: {parsed['error']}"]
         
         children_data = parsed.get("children", [])
-
-        # CRITICAL: Reject any coordinator child nodes
-        coordinator_children = [c for c in children_data if c.get("node_type") == "coordination"]
-        if coordinator_children:
-            coord_names = [c.get("name", "unknown") for c in coordinator_children]
-            return node, [f"Coordinator child nodes are not allowed (found: {coord_names}). The parent IS the coordinator and must directly call all children."]
 
         if not children_data:
             node.stop_decompose = True

--- a/mvp/mvp-0.5.1/main.py
+++ b/mvp/mvp-0.5.1/main.py
@@ -289,6 +289,7 @@ Examples:
         max_retries=args.max_retries,
         max_decompose_retries=args.max_decompose_retries,
         timeout=args.timeout,
+        verbose=args.verbose,
         output_dir=args.output,
         nodes_dir=os.path.join(args.output, "nodes")
     )

--- a/mvp/mvp-0.5.1/tree_builder.py
+++ b/mvp/mvp-0.5.1/tree_builder.py
@@ -77,7 +77,7 @@ class TreeBuilder:
         last_attempt = node.attempt_history[-1] if node.attempt_history else None
         validation = node.validation
 
-        return {
+        ctx = {
             "previous_errors": validation.errors if validation else [],
             "previous_children": last_attempt.children_snapshot if last_attempt else [c.name for c in node.children],
             "previous_contracts": last_attempt.contracts_snapshot if last_attempt else {k: v.to_dict() for k, v in node.children_contracts.items()},
@@ -91,6 +91,21 @@ class TreeBuilder:
                 "composition_feedback": node.composition_feedback.to_dict() if node.composition_feedback else None,
             }
         }
+
+        if self.config.verbose:
+            print("\n" + "=" * 60)
+            print("REDECOMPOSE CONTEXT — FEEDING BACK TO LLM")
+            print("=" * 60)
+            print(f"Node: {node.name}")
+            print(f"Previous children: {ctx['previous_children']}")
+            print(f"Error types: {ctx['validator_report']['error_types']}")
+            print(f"Errors: {ctx['previous_errors']}")
+            if ctx['validator_report']['composition_feedback']:
+                import json as _json
+                print(f"Composition feedback: {_json.dumps(ctx['validator_report']['composition_feedback'], indent=2, ensure_ascii=False)}")
+            print("=" * 60 + "\n")
+
+        return ctx
 
     def _log(self, message: str, indent: int = 0):
         prefix = "  " * indent
@@ -189,6 +204,13 @@ class TreeBuilder:
                     continue
 
             self._log(f"Decomposed into {len(node.children)} children", node.depth)
+
+            if self.config.verbose:
+                print(f"\n  CHILDREN AFTER DECOMPOSITION [{node.name}]:")
+                for c in node.children:
+                    ctype = "leaf" if c.stop_decompose else "parent"
+                    print(f"    [{ctype}] {c.name}: {c.purpose[:100]}")
+                print()
 
             conservation_errors = self.validator.check_conservation(node)
             if conservation_errors:
@@ -385,6 +407,16 @@ class TreeBuilder:
 
             code, code_errors = self.code_generator.generate_with_retry(node)
 
+            if self.config.verbose and code:
+                print("\n" + "-" * 50)
+                print(f"GENERATED CODE [{node.name}]")
+                print("-" * 50)
+                for line in code.strip().split("\n")[:30]:
+                    print(f"  {line}")
+                if len(code.strip().split("\n")) > 30:
+                    print(f"  ... ({len(code.strip().split('\n'))} total lines)")
+                print("-" * 50 + "\n")
+
             if code_errors:
                 if any(e.startswith("CANNOT_COMPOSE") for e in code_errors):
                     node.validation = ValidationResult(
@@ -422,6 +454,19 @@ class TreeBuilder:
                 return True
 
             self._log(f"Validation failed: {validation.errors}", node.depth)
+
+            if self.config.verbose:
+                child_names = {c.name for c in node.children}
+                from validator import Validator as _V
+                _tmp_v = _V(self.config)
+                called = _tmp_v._extract_function_calls(code)
+                used = child_names & called
+                unused = child_names - called
+                print(f"\n  VERBOSE: Child call analysis for [{node.name}]:")
+                print(f"    Called functions in code: {sorted(called)}")
+                print(f"    Children used: {sorted(used)}")
+                print(f"    Children NOT used: {sorted(unused)}")
+                print(f"  (end)\n")
 
             if validation.repair_action == "redecompose" or self.validator.should_redecompose(node, validation):
                 self._log("Re-decomposition required", node.depth)


### PR DESCRIPTION
Correct the dispatcher concept across codebase:
- README: Replace "dispatcher 模式" with precise routing vs cross-cut distinction
- decomposer: Remove overly broad node_type=="coordination" rejection
- Add --verbose logging: decomposer raw output, codegen response, VERIFY verdict, redecompose context